### PR TITLE
feat: add reusable form input component

### DIFF
--- a/src/Pages/AuthModal/AuthModal.jsx
+++ b/src/Pages/AuthModal/AuthModal.jsx
@@ -1,5 +1,6 @@
 import "./AuthModal.scss";
 import { useForm } from "react-hook-form";
+import InputField from "../../utils/InputField";
 
 const AuthModal = ({ onClose, handleLogin, loading, error }) => {
   const { register, handleSubmit, formState, reset } = useForm({
@@ -31,44 +32,39 @@ const AuthModal = ({ onClose, handleLogin, loading, error }) => {
           <div className="auth-modal__divider"></div>
         </div>
         <form onSubmit={handleSubmit(logAuthSubmit)} className="auth-form">
-          <div className="form-group">
-            <label htmlFor="email">Email:</label>
-            <input
-              id="email"
-              type="email"
-              // value={email}
-              placeholder="Введите ваш email"
-              disabled={loading}
-              {...register('email',{
-                required: "Это поле обязательно",
-                pattern: {
-                  value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i,
-                  message: "Email некорректен",
-                },
-              })}
-            />
-          </div>
-          {emailError && <div className="error-message">{emailError}</div>}
-          <div className="form-group">
-            <label htmlFor="password">Пароль:</label>
-            <input
-              id="password"
-              type="password"
-              // value={password}
-              placeholder="Введите ваш пароль"
-              disabled={loading}
-              {...register("password", {
-                required: "Это поле обязательно",
-                pattern: {
-                  value: /^.{6,}$/,
-                  message: "Пароль должен быть не короче 6 символов",
-                },
-              })}
-            />
-          </div>
-          {passwordError && (
-            <div className="error-message">{passwordError}</div>
-          )}
+          <InputField
+            label="Email:"
+            name="email"
+            type="email"
+            placeholder="Введите ваш email"
+            disabled={loading}
+            register={register}
+            validation={{
+              required: "Это поле обязательно",
+              pattern: {
+                value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i,
+                message: "Email некорректен",
+              },
+            }}
+            error={emailError}
+          />
+
+          <InputField
+            label="Пароль:"
+            name="password"
+            type="password"
+            placeholder="Введите ваш пароль"
+            disabled={loading}
+            register={register}
+            validation={{
+              required: "Это поле обязательно",
+              pattern: {
+                value: /^.{6,}$/,
+                message: "Пароль должен быть не короче 6 символов",
+              },
+            }}
+            error={passwordError}
+          />
           <button type="submit" className="auth-button" disabled={loading}>
             {loading ? "Вход..." : "Войти"}
           </button>

--- a/src/Pages/newsAdmin/NewsAdmin.jsx
+++ b/src/Pages/newsAdmin/NewsAdmin.jsx
@@ -4,6 +4,7 @@ import "./NewsAdmin.scss";
 import axiosInstance from "../../API/axiosInstance";
 import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
+import InputField from "../../utils/InputField";
 
 Modal.setAppElement("#root");
 
@@ -257,7 +258,7 @@ const NewsAdmin = () => {
           <form onSubmit={handleSubmit}>
             <div className="modal-section">
               <h3>Заголовок</h3>
-              <input
+              <InputField
                 type="text"
                 name="title"
                 value={newsData.title}
@@ -281,7 +282,7 @@ const NewsAdmin = () => {
 
             <div className="modal-section">
               <h3>Дата</h3>
-              <input
+              <InputField
                 type="datetime-local"
                 name="date"
                 value={newsData.date}

--- a/src/utils/InputField.jsx
+++ b/src/utils/InputField.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+/**
+ * Reusable input field component with optional React Hook Form integration.
+ * - Supports basic validation via `register`.
+ * - Automatically blurs date inputs after selection to close native pickers.
+ */
+const InputField = ({
+  label,
+  name,
+  type = 'text',
+  register,
+  validation = {},
+  error,
+  onChange,
+  ...rest
+}) => {
+  const handleChange = (e) => {
+    if (type === 'date' || type === 'datetime-local') {
+      // Blur after selecting date to close the picker modal
+      e.target.blur();
+    }
+    if (onChange) {
+      onChange(e);
+    }
+  };
+
+  return (
+    <div className="form-group">
+      {label && <label htmlFor={name}>{label}</label>}
+      <input
+        id={name}
+        type={type}
+        {...(register ? register(name, validation) : {})}
+        onChange={handleChange}
+        {...rest}
+      />
+      {error && <div className="error-message">{error}</div>}
+    </div>
+  );
+};
+
+export default InputField;


### PR DESCRIPTION
## Summary
- create shared `InputField` for forms with optional validation and auto-close on date pickers
- refactor auth and news forms to use the reusable field

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68beb253ce088326b1bfd0c5f8e911f3