### PR TITLE
feat: replace alerts with modals and style project info

### DIFF
--- a/src/Elements/ConfirmModal.jsx
+++ b/src/Elements/ConfirmModal.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import Modal from 'react-modal';
+import styles from './ConfirmModal.module.scss';
+
+const ConfirmModal = ({
+  isOpen,
+  message,
+  onConfirm,
+  onCancel,
+  confirmText = 'Подтвердить',
+  cancelText = 'Отмена',
+  hideCancel = false,
+}) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onRequestClose={onCancel}
+      className={styles.modal}
+      overlayClassName={styles.overlay}
+      ariaHideApp={false}
+    >
+      <div className={styles.content}>
+        <p className={styles.message}>{message}</p>
+        <div className={styles.buttons}>
+          {!hideCancel && (
+            <button className={styles.cancel} onClick={onCancel}>
+              {cancelText}
+            </button>
+          )}
+          <button
+            className={styles.confirm}
+            onClick={() => {
+              onConfirm && onConfirm();
+            }}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ConfirmModal;

--- a/src/Elements/ConfirmModal.module.scss
+++ b/src/Elements/ConfirmModal.module.scss
@@ -1,0 +1,65 @@
+.overlay {
+  background: rgba(0, 0, 0, 0.5);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  font-family: 'Calibri', sans-serif;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.message {
+  margin: 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.confirm {
+  background: #4B1218;
+  border: none;
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.confirm:hover {
+  background: #64181f;
+}
+
+.cancel {
+  background: #e0e0e0;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.cancel:hover {
+  background: #d5d5d5;
+}

--- a/src/Elements/MyEvents/MyEvents.module.scss
+++ b/src/Elements/MyEvents/MyEvents.module.scss
@@ -542,3 +542,105 @@
   justify-content: center;
   gap: 20px;
 }
+
+/* InfoModalProject styles */
+.projectImageSection {
+  display: flex;
+  justify-content: center;
+}
+
+.projectPreviewImage {
+  width: 100%;
+  max-height: 200px;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.projectName {
+  font-size: 22px;
+  font-weight: 600;
+  color: #4B1218;
+  text-align: center;
+  margin: 15px 0;
+}
+
+.projectDescription {
+  h4 {
+    margin-bottom: 8px;
+    color: #4B1218;
+  }
+  p {
+    margin: 0;
+    line-height: 1.4;
+  }
+}
+
+.projectDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.detailRow {
+  display: flex;
+  justify-content: space-between;
+  font-size: 16px;
+}
+
+.detailLabel {
+  font-weight: 600;
+  color: #4B1218;
+}
+
+.detailValue {
+  color: #333;
+}
+
+.certificateSection {
+  margin-top: 20px;
+  text-align: center;
+}
+
+.certificateLink {
+  color: #4B1218;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.certificateLink:hover {
+  text-decoration: underline;
+}
+
+.participantsSection {
+  margin-top: 20px;
+}
+
+.loadingText,
+.noParticipants {
+  text-align: center;
+  color: #666;
+}
+
+.participantsList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.participantItem {
+  padding: 6px 10px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+}
+
+.participantName {
+  font-size: 16px;
+  color: #333;
+}
+
+.metaInfo {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}


### PR DESCRIPTION
## Summary
- add reusable ConfirmModal component for consistent confirmation dialogs
- replace browser alerts with ConfirmModal across admin pages
- style project information modal for clearer presentation

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c0034177b08326aa55efa792dffb8d