### PR TITLE
Handle protected join links and project actions

### DIFF
--- a/src/API/useMyEvents.js
+++ b/src/API/useMyEvents.js
@@ -4,30 +4,29 @@ import axiosInstance from "./axiosInstance";
 const useMyEvents = ({ user, page, perPage }) => {
   const [myEvents, setMyEvents] = React.useState([]);
   const [loading, setLoading] = React.useState(false);
-  const [meta, setMeta] = React.useState({}); 
+  const [meta, setMeta] = React.useState({});
+
+  const fetchData = React.useCallback(async () => {
+    if (!user?.id) return;
+    try {
+      setLoading(true);
+      const response = await axiosInstance.get(
+        `/projects/by-user?user_id=${user.id}&page=${page}&per_page=${perPage}`
+      );
+      setMyEvents(response.data.data);
+      setMeta(response.data.meta);
+    } catch (error) {
+      console.error("Ошибка загрузки проектов:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, perPage, user?.id]);
 
   React.useEffect(() => {
-    if (!user) return;
-
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-        const response = await axiosInstance.get(
-          `/projects/by-user?user_id=${user.id}&page=${page}&per_page=${perPage}`
-        );
-        setMyEvents(response.data.data);
-        setMeta(response.data.meta);
-      } catch (error) {
-        console.error("Ошибка загрузки проектов:", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
     fetchData();
-  }, [user?.id, page, perPage]);
+  }, [fetchData]);
 
-  return { myEvents, loading, meta };
+  return { myEvents, setMyEvents, loading, meta, refresh: fetchData };
 };
 
 export default useMyEvents;

--- a/src/Elements/MyEvents/MyEvents.module.scss
+++ b/src/Elements/MyEvents/MyEvents.module.scss
@@ -505,6 +505,17 @@
   font-size: 14px;
 }
 
+.successMessage {
+  color: #0f5132;
+  margin-bottom: 16px;
+  padding: 12px;
+  background-color: #d1e7dd;
+  border-radius: 8px;
+  border: 1px solid #badbcc;
+  width: 100%;
+  font-size: 14px;
+}
+
 .primaryButton {
   background-color: #4B1218;
   color: #fff;
@@ -537,10 +548,34 @@
   color: #111;
 }
 
+.dangerButton {
+  background-color: #ffe8e8;
+  border: 1.5px solid #f5b1b1;
+  color: #b42318;
+  padding: 10px 20px;
+  border-radius: 12px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.dangerButton:hover {
+  background-color: #ffd0d0;
+  border-color: #e08a8a;
+  color: #8f1a10;
+}
+
+.dangerButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .buttonsMyDocum{
   display: flex;
   justify-content: center;
   gap: 20px;
+  flex-wrap: wrap;
 }
 
 /* InfoModalProject styles */

--- a/src/Elements/MyEvents/index.jsx
+++ b/src/Elements/MyEvents/index.jsx
@@ -14,7 +14,7 @@ const MyEvents = () => {
   const [isInfoModalOpen, setIsInfoModalOpen] = React.useState(false);
   const itemsPerPage = 5; 
 
-  const { myEvents, loading, meta } = useMyEvents({
+  const { myEvents, setMyEvents, loading, meta } = useMyEvents({
     user,
     page: currentPage,
     perPage: itemsPerPage
@@ -38,6 +38,28 @@ const MyEvents = () => {
     setIsInfoModalOpen(false);
     setSelectedProject(null);
   };
+
+  const handleProjectUpdate = React.useCallback(
+    (updatedProject) => {
+      if (!updatedProject) return;
+      setMyEvents((prev) =>
+        prev.map((item) => (item.id === updatedProject.id ? updatedProject : item))
+      );
+      setSelectedProject((prev) =>
+        prev?.id === updatedProject.id ? updatedProject : prev
+      );
+    },
+    [setMyEvents]
+  );
+
+  const handleProjectLeave = React.useCallback(
+    (projectId) => {
+      setMyEvents((prev) => prev.filter((item) => item.id !== projectId));
+      setSelectedProject(null);
+      setIsInfoModalOpen(false);
+    },
+    [setMyEvents]
+  );
 
   const handleNextPage = () => {
     if (currentPage < meta.last_page) {
@@ -90,6 +112,8 @@ const MyEvents = () => {
         project={selectedProject}
         isOpen={isInfoModalOpen}
         onRequestClose={closeInfoModal}
+        onProjectUpdate={handleProjectUpdate}
+        onProjectLeave={handleProjectLeave}
       />
 
       {meta.last_page > 1 && (

--- a/src/Pages/Login/LoginPage.jsx
+++ b/src/Pages/Login/LoginPage.jsx
@@ -1,0 +1,118 @@
+import React, { useContext, useEffect, useState, useCallback } from "react";
+import { useForm } from "react-hook-form";
+import { useLocation, useNavigate } from "react-router";
+import { AuthContext } from "../../context/AuthContext";
+import InputField from "../../utils/InputField";
+import "./LoginPage.scss";
+
+const LoginPage = () => {
+  const authContext = useContext(AuthContext);
+  const login = authContext?.login;
+  const isAuthenticated = authContext?.isAuthenticated;
+  const pendingJoinIntent = authContext?.pendingJoinIntent;
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const nextParam = searchParams.get("next");
+
+  const { register, handleSubmit, formState, reset } = useForm({
+    mode: "onChange",
+  });
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const onSubmit = useCallback(
+    async (data) => {
+      if (!login) return;
+      setLoading(true);
+      setError("");
+      const success = await login(data.email, data.password);
+      setLoading(false);
+      if (!success) {
+        setError("Не удалось войти. Проверьте данные и попробуйте снова.");
+        return;
+      }
+      reset();
+    },
+    [login, reset]
+  );
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    const redirectTarget =
+      pendingJoinIntent?.redirectTo ||
+      (nextParam && nextParam.startsWith("/") ? nextParam : null);
+
+    if (redirectTarget) {
+      navigate(redirectTarget, { replace: true });
+    } else {
+      navigate("/profile", { replace: true });
+    }
+  }, [
+    isAuthenticated,
+    navigate,
+    nextParam,
+    pendingJoinIntent?.redirectTo,
+  ]);
+
+  const emailError = formState.errors?.email?.message;
+  const passwordError = formState.errors?.password?.message;
+
+  return (
+    <section className="login-page">
+      <div className="login-card" aria-live="polite">
+        <h1>Вход</h1>
+        <p className="login-subtitle">
+          Введите свои учетные данные, чтобы продолжить работу с платформой.
+        </p>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="login-form">
+          <InputField
+            label="Email"
+            name="email"
+            type="email"
+            placeholder="example@domain.com"
+            disabled={loading}
+            register={register}
+            validation={{
+              required: "Это поле обязательно",
+              pattern: {
+                value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/i,
+                message: "Email некорректен",
+              },
+            }}
+            error={emailError}
+          />
+
+          <InputField
+            label="Пароль"
+            name="password"
+            type="password"
+            placeholder="Введите пароль"
+            disabled={loading}
+            register={register}
+            validation={{
+              required: "Это поле обязательно",
+              minLength: {
+                value: 6,
+                message: "Пароль должен быть не короче 6 символов",
+              },
+            }}
+            error={passwordError}
+          />
+
+          {error && <div className="login-error">{error}</div>}
+
+          <button type="submit" className="login-submit" disabled={loading}>
+            {loading ? "Вход..." : "Войти"}
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+};
+
+export default LoginPage;

--- a/src/Pages/Login/LoginPage.scss
+++ b/src/Pages/Login/LoginPage.scss
@@ -1,0 +1,99 @@
+.login-page {
+  min-height: calc(100vh - 120px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 16px;
+  background-color: #f9fafb;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 420px;
+  background: #ffffff;
+  border-radius: 16px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 12px 32px rgba(79, 70, 229, 0.08);
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.login-card h1 {
+  margin: 0;
+  font-size: 28px;
+  color: #4B1218;
+  text-align: center;
+}
+
+.login-subtitle {
+  margin: 0;
+  text-align: center;
+  color: #6b7280;
+  font-size: 16px;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 8px;
+}
+
+.login-form .form-group label {
+  font-weight: 600;
+  color: #4B1218;
+}
+
+.login-form .form-group input {
+  border-radius: 12px;
+  border: 1.5px solid #d1d5db;
+  padding: 12px 14px;
+  font-size: 16px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-form .form-group input:focus {
+  outline: none;
+  border-color: #4B1218;
+  box-shadow: 0 0 0 3px rgba(75, 18, 24, 0.15);
+}
+
+.login-error {
+  background-color: #fff5f5;
+  color: #b42318;
+  border: 1px solid #ffd6d6;
+  border-radius: 12px;
+  padding: 12px;
+  font-size: 14px;
+  text-align: center;
+}
+
+.login-submit {
+  background-color: #4B1218;
+  color: #ffffff;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 20px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.2s ease;
+}
+
+.login-submit:hover:not(:disabled) {
+  background-color: #64181f;
+  transform: translateY(-1px);
+}
+
+.login-submit:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .login-card {
+    padding: 24px 20px;
+  }
+}


### PR DESCRIPTION
## Summary
- add persistent join intent handling with a dedicated login page and navigation updates
- enforce authentication in the project join route with improved status messaging
- extend the project info modal with certificate access, leave-project flow, and refreshed styling

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68c97a8c064483268f27b39ff9698a5c